### PR TITLE
Integrate dependency injection (DI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+#### 1.4.0
+
+* Add dependency injection (DI) *2016-10-19*
+
+
 #### 1.3.1
 
 * Fix issues with deployer REPO_URL and SLACK_HOOK_URL *2016-09-16*

--- a/app/config/services.php
+++ b/app/config/services.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * @author Adegoke Obasa <goke@cottacush.com>
+ */
+Yii::$container->set('app\services\DummyServiceInterface', 'app\services\DummyService');

--- a/app/controllers/SiteController.php
+++ b/app/controllers/SiteController.php
@@ -2,14 +2,24 @@
 
 namespace app\controllers;
 
+use app\models\ContactForm;
+use app\models\LoginForm;
+use app\services\DummyServiceInterface;
 use Yii;
 use yii\filters\AccessControl;
 use yii\filters\VerbFilter;
-use app\models\LoginForm;
-use app\models\ContactForm;
 
 class SiteController extends BaseController
 {
+    /** @var  DummyServiceInterface */
+    protected $dummyService;
+
+    public function __construct($id, $module, DummyServiceInterface $dummyService, $config = [])
+    {
+        $this->dummyService = $dummyService;
+        parent::__construct($id, $module, $config);
+    }
+
     public function behaviors()
     {
         return [
@@ -51,6 +61,11 @@ class SiteController extends BaseController
         return $this->render('index');
     }
 
+    public function actionServiceTest()
+    {
+        return $this->dummyService->shout("Hello World");
+    }
+
     public function actionLogin()
     {
         if (!\Yii::$app->user->isGuest) {
@@ -88,8 +103,9 @@ class SiteController extends BaseController
 
     public function actionAbout()
     {
-        if($this->getUser()->isGuest)
+        if ($this->getUser()->isGuest) {
             return $this->getUser()->loginRequired();
+        }
         return $this->render('about');
     }
 }

--- a/app/services/DummyService.php
+++ b/app/services/DummyService.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @author Adegoke Obasa <goke@cottacush.com>
+ */
+
+namespace app\services;
+
+use yii\base\Object;
+
+class DummyService extends Object implements DummyServiceInterface
+{
+    public function shout($text)
+    {
+        return $text;
+    }
+}

--- a/app/services/DummyServiceInterface.php
+++ b/app/services/DummyServiceInterface.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @author Adegoke Obasa <goke@cottacush.com>
+ */
+
+namespace app\services;
+
+interface DummyServiceInterface
+{
+    public function shout($text);
+}

--- a/app/web/index.php
+++ b/app/web/index.php
@@ -17,12 +17,12 @@ if (getenv('APPLICATION_ENV') != 'production') {
 $envs = ['development', 'staging', 'production'];
 $env = getenv("APPLICATION_ENV");
 
-if(!in_array($env, $envs)) {
+if (!in_array($env, $envs)) {
     die("Environment is not valid");
 }
 
 // Only show debug toolbar and allow gii when in development
-if($env == "development") {
+if ($env == "development") {
     defined('YII_DEBUG') or define('YII_DEBUG', true);
     defined('YII_ENV') or define('YII_ENV', 'dev');
 }
@@ -32,6 +32,10 @@ require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');
 // Require configuration file
 $config = require(__DIR__ . "/../config/web.php");
 
+
+// Service Dependencies
+require(__DIR__ . "/../config/services.php");
+
 // Change this to your timezone
-ini_set( 'date.timezone', 'Africa/Lagos');
+ini_set('date.timezone', 'Africa/Lagos');
 (new yii\web\Application($config))->run();

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "cottacush/yii2-base-project",
     "description": "A Yii 2 Base Project Template",
     "keywords": ["yii2", "framework", "basic", "project template", "improved"],
-    "version": "1.3.1",
+    "version": "1.4.0",
     "type": "project",
     "license": "MIT",
     "minimum-stability": "stable",


### PR DESCRIPTION
This PR integrates dependency Injection into the base project.
Dependencies are registered in the `app\config\services.php` file, this file is then required in the `app\web\index.php` file.

I implemented a sample service found in `app\services\DummyService`. This service implements the `DummyInterface`.

To test this, you can try the route `site/service-test`.
